### PR TITLE
Only validate the bucket lifecycle config if the validate-only header is set

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5863,9 +5863,8 @@ void RGWPutLC::execute(optional_yield y)
     ldpp_dout(this, 15) << "New LifecycleConfiguration:" << ss.str() << dendl;
   }
 
-  auto validate_only = s->info.env->get("HTTP_X_RGW_VALIDATE_ONLY");
-  if (validate_only != nullptr) {
-    ldpp_dout(this, 0) << "validate-only header set - exiting early" << dendl;
+  if (s->info.env->exists("HTTP_X_RGW_VALIDATE_ONLY")) {
+    ldpp_dout(this, 15) << "x-rgw-validate-only header set - exiting early" << dendl;
     return;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5863,6 +5863,12 @@ void RGWPutLC::execute(optional_yield y)
     ldpp_dout(this, 15) << "New LifecycleConfiguration:" << ss.str() << dendl;
   }
 
+  auto validate_only = s->info.env->get("HTTP_VALIDATE_ONLY");
+  if (validate_only != nullptr) {
+    ldpp_dout(this, 0) << "validate-only header set - exiting early" << dendl;
+    return;
+  }
+
   op_ret = store->forward_request_to_master(this, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5863,7 +5863,7 @@ void RGWPutLC::execute(optional_yield y)
     ldpp_dout(this, 15) << "New LifecycleConfiguration:" << ss.str() << dendl;
   }
 
-  auto validate_only = s->info.env->get("HTTP_VALIDATE_ONLY");
+  auto validate_only = s->info.env->get("HTTP_X_RGW_VALIDATE_ONLY");
   if (validate_only != nullptr) {
     ldpp_dout(this, 0) << "validate-only header set - exiting early" << dendl;
     return;


### PR DESCRIPTION
If the`validate-only` header is present in the `PutBucketLifecycleConfiguration` request then only validate the lifecycle policy, but don't apply it to the bucket. We achieve this by bailing out of the `PutBucketLifecycleConfiguration` handler before storing the changes.