### PR TITLE
protobuf: rename authz_result enum names to conform with golang linter

### DIFF
--- a/src/rgw/protos/authorizer/v1/authorizer.proto
+++ b/src/rgw/protos/authorizer/v1/authorizer.proto
@@ -116,19 +116,19 @@ message PingResponse { AuthorizationCommon common = 1; }
 //
 
 enum AuthorizationResultCode {
-  AUTHZ_RESULT_UNSPECIFIED = 0;
+  AUTHORIZATION_RESULT_CODE_UNSPECIFIED = 0;
   // Proceed with the request, which is now authorized.
-  AUTHZ_RESULT_ALLOW = 1;
+  AUTHORIZATION_RESULT_CODE_ALLOW = 1;
   // Refuse the request and stop further processing.
-  AUTHZ_RESULT_DENY = 2;
+  AUTHORIZATION_RESULT_CODE_DENY = 2;
   // This value means that the Authorizer needs more data from Ceph to
   // authorize. The client must either provide those data or fail the
   // authorization entirely.
-  AUTHZ_RESULT_EXTRA_DATA_REQUIRED = 3;
+  AUTHORIZATION_RESULT_CODE_EXTRA_DATA_REQUIRED = 3;
   // An internal error occurred. This should be logged and investigated.
-  AUTHZ_RESULT_INTERNAL_ERROR = 4;
+  AUTHORIZATION_RESULT_CODE_INTERNAL_ERROR = 4;
   // We have exceeded a rate limit on the Authorizer.
-  AUTHZ_RESULT_RATE_LIMIT_EXCEEDED = 5;
+  AUTHORIZATION_RESULT_CODE_RATE_LIMIT_EXCEEDED = 5;
   // XXX this will almost certainly need extended.
 }
 
@@ -308,7 +308,7 @@ message AuthorizeV2Answer
   AuthorizationResultCode code = 3;
   // Was the 'http code hint' field. Noone has asked for that.
   reserved 4;
-  // If result.code is AUTHZ_RESULT_EXTRA_DATA_REQUIRED, this field must be
+  // If result.code is AUTHORIZATION_RESULT_CODE_EXTRA_DATA_REQUIRED, this field must be
   // present and must list the extra data fields required by the Authorizer in
   // order to properly authorize the request.
   optional ExtraDataSpecification extra_data_required = 5;

--- a/src/rgw/rgw_handoff_impl.cc
+++ b/src/rgw/rgw_handoff_impl.cc
@@ -1098,7 +1098,7 @@ std::vector<int> HandoffHelperImpl::verify_permissions(const RGWOp* op, req_stat
   /* AuthorizeV2 request. We can submit at most two of these requests. The
    * first request will (in the first iteration of this client) never have the
    * extra_data_required field set. If the server responds with
-   * AUTHZ_RESULT_EXTRA_DATA_REQUIRED, we then fetch what data it asks for and
+   * AUTHORIZATION_RESULT_CODE_EXTRA_DATA_REQUIRED, we then fetch what data it asks for and
    * resubmit.
    *
    * We submit at most two requests. We don't allow loops.
@@ -1203,16 +1203,16 @@ std::vector<int> HandoffHelperImpl::verify_permissions(const RGWOp* op, req_stat
     using namespace ::authorizer::v1;
     int retcode;
     switch (answer.code()) {
-    case AUTHZ_RESULT_ALLOW:
+    case AUTHORIZATION_RESULT_CODE_ALLOW:
       retcode = 0;
       break;
-    case AUTHZ_RESULT_DENY:
+    case AUTHORIZATION_RESULT_CODE_DENY:
       retcode = -EACCES;
       break;
-    case AUTHZ_RESULT_INTERNAL_ERROR:
+    case AUTHORIZATION_RESULT_CODE_INTERNAL_ERROR:
       retcode = -ERR_INTERNAL_ERROR;
       break;
-    case AUTHZ_RESULT_RATE_LIMIT_EXCEEDED:
+    case AUTHORIZATION_RESULT_CODE_RATE_LIMIT_EXCEEDED:
       retcode = -ERR_RATE_LIMITED;
       break;
     default:
@@ -1541,7 +1541,7 @@ AuthorizerClient::AuthorizeResult AuthorizerClient::AuthorizeV2(AuthorizeV2Reque
     // 'Allow', we'll return an error. A caller that sends multiple requests
     // will have to check each one.
     for (const auto& answer : resp.answers()) {
-      if (answer.code() != AuthorizationResultCode::AUTHZ_RESULT_ALLOW) {
+      if (answer.code() != AuthorizationResultCode::AUTHORIZATION_RESULT_CODE_ALLOW) {
         return AuthorizeResult(false, req, resp);
       }
     }
@@ -1567,7 +1567,7 @@ bool AuthorizerClient::AuthorizeResult::is_extra_data_required() const
     return false;
   }
   for (const auto& answer : response().answers()) {
-    if (answer.code() == ::authorizer::v1::AUTHZ_RESULT_EXTRA_DATA_REQUIRED) {
+    if (answer.code() == ::authorizer::v1::AUTHORIZATION_RESULT_CODE_EXTRA_DATA_REQUIRED) {
       return true;
     }
   }

--- a/src/test/rgw/test_rgw_auth_handoff.cc
+++ b/src/test/rgw/test_rgw_auth_handoff.cc
@@ -1490,7 +1490,7 @@ public:
   }
 
 private:
-  static constexpr std::array<::authorizer::v1::AuthorizationResultCode, 1> standard_canned_answers_ { ::authorizer::v1::AUTHZ_RESULT_ALLOW };
+  static constexpr std::array<::authorizer::v1::AuthorizationResultCode, 1> standard_canned_answers_ { ::authorizer::v1::AUTHORIZATION_RESULT_CODE_ALLOW };
 
   DoutPrefix dpp_ { g_ceph_context, ceph_subsys_rgw, "unittest gRPC authz server " };
   std::vector<::authorizer::v1::AuthorizationResultCode> canned_answers_;
@@ -1661,7 +1661,7 @@ TEST_F(AuthzGRPCTest, AuthorizeBasicSingleQuestion)
   auto req = res.request();
   ASSERT_GT(ans.common().timestamp(), req.questions(0).common().timestamp()) << "timestamp ordering";
   ASSERT_EQ(ans.common().authorization_id(), req.questions(0).common().authorization_id()) << "authorization_id mismatch";
-  ASSERT_EQ(ans.code(), AUTHZ_RESULT_ALLOW) << "code mismatch";
+  ASSERT_EQ(ans.code(), AUTHORIZATION_RESULT_CODE_ALLOW) << "code mismatch";
 }
 
 TEST_F(AuthzGRPCTest, AuthorizeBasicMultipleQuestion)
@@ -1699,7 +1699,7 @@ TEST_F(AuthzGRPCTest, AuthorizeBasicMultipleQuestion)
     ASSERT_GT(ans.common().timestamp(), req.questions(n).common().timestamp()) << "answer " << n << "timestamp ordering";
     ASSERT_EQ(ans.common().authorization_id(), req.questions(n).common().authorization_id())
         << "answer " << n << "authorization_id mismatch";
-    ASSERT_EQ(ans.code(), AUTHZ_RESULT_ALLOW) << "answer " << n << "code mismatch";
+    ASSERT_EQ(ans.code(), AUTHORIZATION_RESULT_CODE_ALLOW) << "answer " << n << "code mismatch";
   }
 }
 
@@ -1721,7 +1721,7 @@ TEST_F(AuthzGRPCTest, AuthorizeBasicSingleQuestionExpectedFail)
   ASSERT_THAT(opt_req, testing::Ne(std::nullopt));
 
   // Set a failure code.
-  authz_server().instance()->set_canned_results({ ::authorizer::v1::AUTHZ_RESULT_DENY });
+  authz_server().instance()->set_canned_results({ ::authorizer::v1::AUTHORIZATION_RESULT_CODE_DENY });
 
   // Note that this will std::move the request!
   auto res = client.AuthorizeV2(*opt_req);
@@ -1737,7 +1737,7 @@ TEST_F(AuthzGRPCTest, AuthorizeBasicSingleQuestionExpectedFail)
   auto ans = resp.answers(0);
   ASSERT_GT(ans.common().timestamp(), req.questions(0).common().timestamp()) << "timestamp ordering";
   ASSERT_EQ(ans.common().authorization_id(), req.questions(0).common().authorization_id()) << "authorization_id mismatch";
-  ASSERT_EQ(ans.code(), AUTHZ_RESULT_DENY) << "code mismatch";
+  ASSERT_EQ(ans.code(), AUTHORIZATION_RESULT_CODE_DENY) << "code mismatch";
 }
 
 TEST_F(AuthzGRPCTest, AuthorizeBasicMultipleQuestionExpectedFail)
@@ -1760,7 +1760,7 @@ TEST_F(AuthzGRPCTest, AuthorizeBasicMultipleQuestionExpectedFail)
 
   // Set a failure code for the last question.
   using namespace ::authorizer::v1;
-  auto cr = std::vector<AuthorizationResultCode> { AUTHZ_RESULT_ALLOW, AUTHZ_RESULT_ALLOW, AUTHZ_RESULT_DENY };
+  auto cr = std::vector<AuthorizationResultCode> { AUTHORIZATION_RESULT_CODE_ALLOW, AUTHORIZATION_RESULT_CODE_ALLOW, AUTHORIZATION_RESULT_CODE_DENY };
   authz_server().instance()->set_canned_results(cr);
 
   // Note that this will std::move the request!


### PR DESCRIPTION
microservices linter config enforces enum names align with enum type name